### PR TITLE
refactor time stamp extraction

### DIFF
--- a/lib/acapi/amqp/in_message.rb
+++ b/lib/acapi/amqp/in_message.rb
@@ -21,13 +21,7 @@ module Acapi
 
       def extract_start_time(props)
         headers = props[:headers] || {}
-        ts_val = Time.now
-        if headers.has_key?("submitted_timestamp")
-          ts_val = headers["submitted_timestamp"]
-        elsif headers.has_key?(:submitted_timestamp)
-          ts_val = headers[:submitted_timestamp]
-        end
-        ts_val
+        headers[:submitted_timestamp] || headers["submitted_timestamp"] || Time.now
       end
 
       def extract_event_name(di)


### PR DESCRIPTION
key can be defined yet be assigned a nil value. we want the key to be defined _and_ have a non-nil value.  undefined keys always return nil.

Time.now = nil || nil || Time.now